### PR TITLE
Adds responsive css

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -159,3 +159,61 @@ body {
     background: #111
   }
 }
+
+@media (max-width: 705px) {
+  .game {
+    flex-direction: column;
+    align-items: center;
+    padding: 30px 0px;
+  }
+
+  .square {
+    width: 100px;
+    height: 100px;
+    line-height: 100px;
+  }
+
+  .status {
+    text-align: center;
+  }
+  .turn-button {
+    text-align: center;
+  }
+
+  ul {
+    padding-inline-start: 0px;
+    list-style-type: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .square {
+    width: 75px;
+    height: 75px;
+    line-height: 75px;
+  }
+
+  .turn-button {
+    text-align: center;
+    padding: 5px 0px;
+  }
+}
+
+@media (max-width: 275px) {
+  .square {
+    width: 40px;
+    height: 40px;
+    line-height: 40px;
+    font-size: 36px;
+  }
+
+  li > h3 {
+    padding-left: 0px;
+  }
+}
+
+@media (max-width: 174px) {
+  .game {
+    display: none;
+  }
+}


### PR DESCRIPTION
## :writing_hand: Description
Decided that those of the mobile persuasion should be able to try this out without it breaking! Added a few breakpoints to update css.

## :camera: Visual
Large Size:
![LSizeCss](https://github.com/ThamasMc/react-tac-toe/assets/26549788/8f26a7e8-5e03-48ba-be6e-9572d3e45040)

Medium Size:
![MSizeCss](https://github.com/ThamasMc/react-tac-toe/assets/26549788/b859d17a-8f3d-4f2a-a7d8-ff1f5b55a590)

Small Size:
![SSizeCss](https://github.com/ThamasMc/react-tac-toe/assets/26549788/89bde14b-dddc-4ed0-8e61-446c349b85e6)


XSmall Size:
![XSCss](https://github.com/ThamasMc/react-tac-toe/assets/26549788/74bbef75-a084-4233-91be-4b6844670680)

***
Anything smaller than the extra small just hides the game, so that if your screen goes small, you don't get a bunch of spaghetti.