### PR TITLE
Fixes netlify builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "build-netlify": "PUBLIC_URL=/ react-scripts build",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "test": "react-scripts test --env=jsdom",


### PR DESCRIPTION
## :writing_hand: Description
Netlify was broken because Github Pages deploys require the addition of an
extra path for the repository that doesn't exist for Netlify.

I've added a build script that sets the `PUBLIC_URL` to `/` to workaround the homepage setting in the package json.

